### PR TITLE
Adding Laravel 5.3 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,3 @@
-/.idea/
-/_arcanedev/
 /build/
 /vendor/
 /composer.phar

--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -20,7 +20,7 @@ checks:
 
 tools:
     external_code_coverage:
-        timeout: 600
+        timeout: 1200
         runs: 12
     php_code_sniffer:
         enabled: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,9 @@ language: php
 sudo: false
 
 php:
-  - 5.5.9
-  - 5.5
   - 5.6
   - 7.0
+  - 7.1
   - nightly
   - hhvm
 
@@ -18,6 +17,7 @@ env:
   - TESTBENCH_VERSION=3.0.*
   - TESTBENCH_VERSION=3.1.*
   - TESTBENCH_VERSION=3.2.*
+  - TESTBENCH_VERSION=3.3.*
 
 before_script:
   - travis_retry composer self-update

--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@ Feel free to check out the [releases](https://github.com/ARCANEDEV/Gravatar/rele
 
 ### Features
 
-  * Framework-agnostic (Works in any PHP projects).
-  * Laravel 5.0, 5.1 & 5.2 are Supported.
+  * Framework-agnostic package.
+  * Laravel `5.0 | 5.1 | 5.2 | 5.3` are Supported.
   * Easy setup & configuration.
   * Well tested (100% code coverage with maximum code quality).
   * Made with :heart: &amp; :coffee:.

--- a/_docs/0-Home.md
+++ b/_docs/0-Home.md
@@ -6,8 +6,8 @@ Feel free to check out the [releases](https://github.com/ARCANEDEV/Gravatar/rele
 
 ### Features
 
-  * Framework-agnostic (Works in any PHP projects).
-  * Laravel 5.0, 5.1 & 5.2 are Supported.
+  * Framework-agnostic package.
+  * Laravel `5.0 | 5.1 | 5.2 | 5.3` are Supported.
   * Easy setup & configuration.
   * Well tested (100% code coverage with maximum code quality).
   * Made with :heart: &amp; :coffee:.

--- a/_docs/1-Requirements.md
+++ b/_docs/1-Requirements.md
@@ -4,4 +4,4 @@
 
 The Gravatar package has a few system requirements:
 
-    - PHP >= 5.5.9
+    - PHP >= 5.6

--- a/_docs/3-Configuration.md
+++ b/_docs/3-Configuration.md
@@ -16,6 +16,8 @@ Allowed defaults:
 | `wavatar`   | generated faces with differing features and backgrounds.                                                              |
 | `retro`     | awesome generated, 8-bit arcade-style pixelated faces.                                                                |
 
+> **Note :** You can also specify an image URL as a default image.
+
 Example images can be viewed on [the Gravatar website](https://gravatar.com/site/implement/images/).
 
 ### Size

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     "type":    "library",
     "license": "MIT",
     "require": {
-        "php" :              ">=5.5.9",
+        "php" :              ">=5.6",
         "arcanedev/support": "~3.0"
     },
     "require-dev": {

--- a/config/gravatar.php
+++ b/config/gravatar.php
@@ -1,11 +1,12 @@
 <?php
 
-// For more details: https://fr.gravatar.com/site/implement/images/
+// For more details: https://en.gravatar.com/site/implement/images/
+
 return [
     /* ------------------------------------------------------------------------------------------------
      |  Default
      | ------------------------------------------------------------------------------------------------
-     |  The default avatar to display if we have no results.
+     |  The default avatar to display if we have no results (you can also set a default image url).
      |
      |  Supported:
      |    * false

--- a/src/Gravatar.php
+++ b/src/Gravatar.php
@@ -122,7 +122,7 @@ class Gravatar implements Contracts\Gravatar
      *
      * @param  string|false  $image
      *
-     * @return self
+     * @return \Arcanedev\Gravatar\Gravatar
      *
      * @throws \Arcanedev\Gravatar\Exceptions\InvalidImageUrlException
      */
@@ -131,12 +131,9 @@ class Gravatar implements Contracts\Gravatar
         if ($image !== false) {
             $this->cachedParams = null;
 
-            if (in_array(strtolower($image), $this->supportedImages)) {
-                $image = strtolower($image);
-            }
-            else {
-                $this->checkImageUrl($image);
-            }
+            $image = in_array(strtolower($image), $this->supportedImages)
+                ? strtolower($image)
+                : $this->checkImageUrl($image);
         }
 
         $this->defaultImage = $image;
@@ -159,7 +156,7 @@ class Gravatar implements Contracts\Gravatar
      *
      * @param integer $size - The avatar size to use, must be less than 512 and greater than 0.
      *
-     * @return self
+     * @return \Arcanedev\Gravatar\Gravatar
      *
      * @throws \Arcanedev\Gravatar\Exceptions\InvalidImageSizeException
      */
@@ -201,7 +198,7 @@ class Gravatar implements Contracts\Gravatar
      *
      * @param  string  $rating
      *
-     * @return self
+     * @return \Arcanedev\Gravatar\Gravatar
      *
      * @throws \Arcanedev\Gravatar\Exceptions\InvalidImageRatingException
      */
@@ -310,7 +307,7 @@ class Gravatar implements Contracts\Gravatar
     /**
      * Enable the use of the secure protocol for image URLs.
      *
-     * @return self
+     * @return \Arcanedev\Gravatar\Gravatar
      */
     public function enableSecure()
     {
@@ -322,7 +319,7 @@ class Gravatar implements Contracts\Gravatar
     /**
      * Disable the use of the secure protocol for image URLs.
      *
-     * @return self
+     * @return \Arcanedev\Gravatar\Gravatar
      */
     public function disableSecure()
     {
@@ -368,6 +365,8 @@ class Gravatar implements Contracts\Gravatar
      *
      * @param  string  $image
      *
+     * @return string
+     *
      * @throws \Arcanedev\Gravatar\Exceptions\InvalidImageUrlException
      */
     private function checkImageUrl($image)
@@ -377,6 +376,8 @@ class Gravatar implements Contracts\Gravatar
                 'The default image specified is not a recognized gravatar "default" and is not a valid URL'
             );
         }
+
+        return $image;
     }
 
     /* ------------------------------------------------------------------------------------------------

--- a/src/GravatarServiceProvider.php
+++ b/src/GravatarServiceProvider.php
@@ -15,13 +15,6 @@ class GravatarServiceProvider extends ServiceProvider
      | ------------------------------------------------------------------------------------------------
      */
     /**
-     * Vendor name.
-     *
-     * @var string
-     */
-    protected $vendor  = 'arcanedev';
-
-    /**
      * Package name.
      *
      * @var string

--- a/tests/GravatarServiceProviderTest.php
+++ b/tests/GravatarServiceProviderTest.php
@@ -62,6 +62,6 @@ class GravatarServiceProviderTest extends TestCase
             \Arcanedev\Gravatar\Contracts\Gravatar::class,
         ];
 
-        $this->assertEquals($expected, $this->provider->provides());
+        $this->assertSame($expected, $this->provider->provides());
     }
 }

--- a/tests/GravatarTest.php
+++ b/tests/GravatarTest.php
@@ -62,7 +62,7 @@ class GravatarTest extends TestCase
         foreach (range($mix, $max) as $size) {
             $this->gravatar->setSize($size);
 
-            $this->assertEquals($size, $this->gravatar->getSize());
+            $this->assertSame($size, $this->gravatar->getSize());
         }
     }
 
@@ -111,18 +111,18 @@ class GravatarTest extends TestCase
     }
 
     /** @test */
-    public function it_can_setand_get_default_image_url()
+    public function it_can_set_and_get_default_image_url()
     {
         $this->gravatar = new Gravatar('http://www.hello.com/img.png');
 
-        $this->assertEquals(
+        $this->assertSame(
             "https://secure.gravatar.com/avatar/00000000000000000000000000000000?s=80&r=g&d=http%3A%2F%2Fwww.hello.com%2Fimg.png&f=y",
             $this->gravatar->get('')
         );
 
         $hashed = md5($this->email);
 
-        $this->assertEquals(
+        $this->assertSame(
             "https://secure.gravatar.com/avatar/$hashed?s=80&r=g&d=http%3A%2F%2Fwww.hello.com%2Fimg.png",
             $this->gravatar->get($this->email)
         );
@@ -156,7 +156,7 @@ class GravatarTest extends TestCase
         $expected = md5($this->email);
 
         foreach ($emails as $email) {
-            $this->assertEquals(
+            $this->assertSame(
                 $expected, $this->gravatar->hashEmail($email)
             );
         }
@@ -178,7 +178,7 @@ class GravatarTest extends TestCase
         foreach($emails as $email) {
             $url = $this->gravatar->get($email);
 
-            $this->assertEquals(1, preg_match($pattern, $url));
+            $this->assertSame(1, preg_match($pattern, $url));
         }
     }
 
@@ -187,8 +187,8 @@ class GravatarTest extends TestCase
     {
         $expected = 'https://secure.gravatar.com/avatar/00000000000000000000000000000000?s=80&r=g&d=identicon&f=y';
 
-        $this->assertEquals($expected, $this->gravatar->get(''));
-        $this->assertEquals($expected, $this->gravatar->get('', false));
+        $this->assertSame($expected, $this->gravatar->get(''));
+        $this->assertSame($expected, $this->gravatar->get('', false));
     }
 
     /** @test */
@@ -196,21 +196,21 @@ class GravatarTest extends TestCase
     {
         $hashed = md5($this->email);
 
-        $this->assertEquals(
+        $this->assertSame(
             "https://secure.gravatar.com/avatar/$hashed?s=80&r=g&d=identicon",
             $this->gravatar->src($this->email)
         );
 
         $size   = 128;
 
-        $this->assertEquals(
+        $this->assertSame(
             "https://secure.gravatar.com/avatar/$hashed?s=$size&r=g&d=identicon",
             $this->gravatar->src($this->email, $size)
         );
 
         $rating = 'r';
 
-        $this->assertEquals(
+        $this->assertSame(
             "https://secure.gravatar.com/avatar/$hashed?s=$size&r=$rating&d=identicon",
             $this->gravatar->src($this->email, $size, $rating)
         );
@@ -221,19 +221,19 @@ class GravatarTest extends TestCase
     {
         $hashed = md5($this->email);
 
-        $this->assertEquals(
+        $this->assertSame(
             "<img src=\"https://secure.gravatar.com/avatar/$hashed?s=80&r=g&d=identicon\">",
             $this->gravatar->image($this->email)
         );
 
         $alt = 'ARCANEDEV';
 
-        $this->assertEquals(
+        $this->assertSame(
             "<img src=\"https://secure.gravatar.com/avatar/$hashed?s=80&r=g&d=identicon\" alt=\"$alt\">",
             $this->gravatar->image($this->email, $alt)
         );
 
-        $this->assertEquals(
+        $this->assertSame(
             "<img src=\"https://secure.gravatar.com/avatar/$hashed?s=80&r=g&d=identicon\" class=\"img-responsive\" alt=\"$alt\">",
             $this->gravatar->image($this->email, $alt, ['class'  => 'img-responsive'])
         );
@@ -252,7 +252,7 @@ class GravatarTest extends TestCase
     {
         $this->gravatar = new Gravatar(false);
 
-        $this->assertEquals(
+        $this->assertSame(
             'https://secure.gravatar.com/avatar/00000000000000000000000000000000?s=80&r=g&f=y',
             $this->gravatar->get('')
         );
@@ -263,19 +263,19 @@ class GravatarTest extends TestCase
     {
         $this->gravatar->image('', null, ['width' => 32]);
 
-        $this->assertEquals(32, $this->gravatar->getSize());
+        $this->assertSame(32, $this->gravatar->getSize());
 
         $this->gravatar->image('', null, ['height' => 64]);
 
-        $this->assertEquals(64, $this->gravatar->getSize());
+        $this->assertSame(64, $this->gravatar->getSize());
 
         $this->gravatar->image('', null, ['width' => 64, 'height' => 128]);
 
-        $this->assertEquals(128, $this->gravatar->getSize());
+        $this->assertSame(128, $this->gravatar->getSize());
 
         $this->gravatar->image('', null, ['width' => 256, 'height' => 128]);
 
-        $this->assertEquals(256, $this->gravatar->getSize());
+        $this->assertSame(256, $this->gravatar->getSize());
     }
 
     /* ------------------------------------------------------------------------------------------------
@@ -290,8 +290,8 @@ class GravatarTest extends TestCase
     public function assertGravatarInstance($gravatar)
     {
         $this->assertInstanceOf(\Arcanedev\Gravatar\Gravatar::class, $gravatar);
-        $this->assertEquals('g', $gravatar->getRating());
-        $this->assertEquals(80, $gravatar->getSize());
+        $this->assertSame('g', $gravatar->getRating());
+        $this->assertSame(80, $gravatar->getSize());
         $this->assertTrue($gravatar->isSecured());
     }
 }

--- a/tests/Helpers/HtmlBuilderTest.php
+++ b/tests/Helpers/HtmlBuilderTest.php
@@ -18,7 +18,7 @@ class HtmlBuilderTest extends TestCase
     /** @test */
     public function it_can_build_image_tag()
     {
-        $this->assertEquals(
+        $this->assertSame(
             '<img src="assets/img/logo.png" class="img-responsive" required="required" alt="Logo">',
             HtmlBuilder::image('assets/img/logo.png', 'Logo', [
                 'class'  => 'img-responsive', 'required'

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -63,14 +63,4 @@ abstract class TestCase extends BaseTestCase
             'Gravatar' => \Arcanedev\Gravatar\Facades\Gravatar::class,
         ];
     }
-
-    /**
-     * Define environment setup.
-     *
-     * @param  \Illuminate\Foundation\Application   $app
-     */
-    protected function getEnvironmentSetUp($app)
-    {
-        //
-    }
 }


### PR DESCRIPTION
- Dropping PHP version less than `5.5`.
- Cleaning/Updating the package.
- More robust test assertions.

cc: @JoeDawson
